### PR TITLE
fix: Formatting adheres to gofmt, error propagation in Top(), Pop()

### DIFF
--- a/data-structures/stack/Stack.go
+++ b/data-structures/stack/Stack.go
@@ -1,51 +1,49 @@
 package main
 
 import (
-    "fmt"
+	"fmt"
 )
 
 type StackNode struct {
-    data int
-    next * StackNode
+	data int
+	next *StackNode
 }
 
 type Stack struct {
-    head * StackNode
-    size int
+	head *StackNode
+	size int
 }
 
-func(s * Stack) Push(data int) {
-    newNode:= & StackNode {
-        data: data,
-    }
-    newNode.next = s.head
-    s.head = newNode
-    s.size++
+func (s *Stack) Push(data int) {
+	newNode := &StackNode{
+		data: data,
+	}
+	newNode.next = s.head
+	s.head = newNode
+	s.size++
 }
 
-func(s * Stack) Pop() int {
-    if s.head == nil {
-        fmt.Println("Stack is empty")
-        return -1
-    }
-    val:= s.head.data
-    s.head = s.head.next
-    s.size--
-        return val
+func (s *Stack) Pop() (int, error) {
+	if s.head == nil {
+		return 0, fmt.Errorf("stack is empty")
+	}
+	val := s.head.data
+	s.head = s.head.next
+	s.size--
+	return val, nil
 }
 
-func(s * Stack) Top() int {
-    if s.head == nil {
-        fmt.Println("Stack is empty")
-        return -1
-    }
-    return s.head.data
+func (s *Stack) Top() (int, error) {
+	if s.head == nil {
+		return 0, fmt.Errorf("stack is empty")
+	}
+	return s.head.data, nil
 }
 
-func(s * Stack) Size() int {
-    return s.size
+func (s *Stack) Size() int {
+	return s.size
 }
 
-func(s * Stack) IsEmpty() bool {
-    return s.size == 0
+func (s *Stack) IsEmpty() bool {
+	return s.size == 0
 }


### PR DESCRIPTION
## Description
The current Go code for stack was unformatted. Golang has the `gofmt` with standard conventions for formatting across the entire language. The Go contributors to this repository can install it and enable it to run 'On Save' via extensions or plugins.

Additionally, the `Pop()` and `Top()` methods were returning -1 in case of empty stack; one can argue that -1 was the topmost element of the stack. While this approach has often been taken in certain languages, but for Golang, it is idiomatic to propagate the error to the parent function which is calling it. Hence, I have updated the code to handle it gracefully with no edge cases.

Please review and merge @arhamgarg