### PR TITLE
Add PopFront() and PopRear() methods to return and remove elements

### DIFF
--- a/data-structures/deque/Deque.go
+++ b/data-structures/deque/Deque.go
@@ -1,7 +1,5 @@
 package main
 
-import "fmt"
-
 type Node struct {
 	data int
 	prev *Node
@@ -41,11 +39,11 @@ func (dq *Deque) AddRear(data int) {
 	}
 }
 
-func (dq *Deque) DeleteFront() {
+func (dq *Deque) PopFront() int {
 	if dq.IsEmpty() {
-		fmt.Println("Deque is empty")
-		return
+		panic("Deque is empty")
 	}
+	data := dq.front.data
 	if dq.front == dq.rear {
 		dq.front = nil
 		dq.rear = nil
@@ -53,13 +51,14 @@ func (dq *Deque) DeleteFront() {
 		dq.front = dq.front.next
 		dq.front.prev = nil
 	}
+	return data
 }
 
-func (dq *Deque) DeleteRear() {
+func (dq *Deque) PopRear() int {
 	if dq.IsEmpty() {
-		fmt.Println("Deque is empty")
-		return
+		panic("Deque is empty")
 	}
+	data := dq.rear.data
 	if dq.front == dq.rear {
 		dq.front = nil
 		dq.rear = nil
@@ -67,6 +66,7 @@ func (dq *Deque) DeleteRear() {
 		dq.rear = dq.rear.prev
 		dq.rear.next = nil
 	}
+	return data
 }
 
 func (dq *Deque) PeekFront() int {

--- a/data-structures/deque/Deque.go
+++ b/data-structures/deque/Deque.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+	"errors"
+)
+
 type Node struct {
 	data int
 	prev *Node
@@ -39,9 +43,9 @@ func (dq *Deque) AddRear(data int) {
 	}
 }
 
-func (dq *Deque) PopFront() int {
+func (dq *Deque) PopFront() (int,error) {
 	if dq.IsEmpty() {
-		panic("Deque is empty")
+		return 0, errors.New("deque is empty")
 	}
 	data := dq.front.data
 	if dq.front == dq.rear {
@@ -51,12 +55,12 @@ func (dq *Deque) PopFront() int {
 		dq.front = dq.front.next
 		dq.front.prev = nil
 	}
-	return data
+	return data,nil
 }
 
-func (dq *Deque) PopRear() int {
+func (dq *Deque) PopRear() (int, error) {
 	if dq.IsEmpty() {
-		panic("Deque is empty")
+		return 0, errors.New("deque is empty")
 	}
 	data := dq.rear.data
 	if dq.front == dq.rear {
@@ -66,19 +70,19 @@ func (dq *Deque) PopRear() int {
 		dq.rear = dq.rear.prev
 		dq.rear.next = nil
 	}
-	return data
+	return data,nil
 }
 
-func (dq *Deque) PeekFront() int {
+func (dq *Deque) PeekFront() (int,error) {
 	if dq.IsEmpty() {
-		panic("Deque is empty")
+		return 0, errors.New("deque is empty")
 	}
-	return dq.front.data
+	return dq.front.data,nil
 }
 
-func (dq *Deque) PeekRear() int {
+func (dq *Deque) PeekRear() (int,error) {
 	if dq.IsEmpty() {
-		panic("Deque is empty")
+		return 0, errors.New("deque is empty")
 	}
-	return dq.rear.data
+	return dq.rear.data,nil
 }

--- a/data-structures/queue/Queue.go
+++ b/data-structures/queue/Queue.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-    "fmt"
+    "errors"
 )
 
 type QueueNode struct {
@@ -32,23 +32,21 @@ func(q * Queue) Enqueue(data int) {
     q.size++
 }
 
-func(q * Queue) Dequeue() int {
+func(q * Queue) Dequeue() (int,error) {
     if q.head == nil {
-        fmt.Println("Queue is empty")
-        return -1
+		return 0, errors.New("queue is empty")
     }
     val:= q.head.data
     q.head = q.head.next
     q.size--
-        return val
+        return val,nil
 }
 
-func(q * Queue) Front() int {
+func(q * Queue) Front() (int, error) {
     if q.head == nil {
-        fmt.Println("Queue is empty")
-        return -1
+		return 0, errors.New("queue is empty")
     }
-    return q.head.data
+    return q.head.data,nil
 }
 
 func(q * Queue) Size() int {

--- a/data-structures/stack/Stack.go
+++ b/data-structures/stack/Stack.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 )
 
 type StackNode struct {
@@ -25,7 +25,7 @@ func (s *Stack) Push(data int) {
 
 func (s *Stack) Pop() (int, error) {
 	if s.head == nil {
-		return 0, fmt.Errorf("stack is empty")
+		return 0, errors.New("stack is empty")
 	}
 	val := s.head.data
 	s.head = s.head.next
@@ -35,7 +35,7 @@ func (s *Stack) Pop() (int, error) {
 
 func (s *Stack) Top() (int, error) {
 	if s.head == nil {
-		return 0, fmt.Errorf("stack is empty")
+		return 0, errors.New("stack is empty")
 	}
 	return s.head.data, nil
 }


### PR DESCRIPTION
### Changes
- Added PopFront() and PopRear() methods to replace DeleteFront() and DeleteRear().
- Each method now returns the removed element in addition to removing it from the deque.
- Improved consistency with standard deque operations in other languages.

