### PR TITLE
Fix incorrect constructor name in Queue in java

### DIFF
--- a/data-structures/linear/queue/Queue.java
+++ b/data-structures/linear/queue/Queue.java
@@ -12,7 +12,7 @@ public class Queue {
   private Node head;
   private int size;
 
-  public Stack() {
+  public Queue() {
     head = null;
     size = 0;
   }


### PR DESCRIPTION
Renamed constructor from Stack to Queue to correctly match the class name.