### PR TITLE
feat: Recursive DFS in Graph using Go

### DIFF
--- a/algorithms/graph/dfs/search.go
+++ b/algorithms/graph/dfs/search.go
@@ -1,0 +1,29 @@
+package main
+
+import "fmt"
+
+func dfs(graph map[string][]string, start string, visited map[string]bool) {
+	visited[start] = true // mark current node as visited
+
+	fmt.Println(start)
+
+	for _, neighbour := range graph[start] {
+		if !visited[neighbour] {
+			dfs(graph, neighbour, visited)
+		}
+	}
+}
+
+func main() {
+	graph := map[string][]string{
+		"A": {"B", "C"},
+		"B": {"D", "E"},
+		"C": {"F"},
+		"D": {},
+		"E": {"F"},
+		"F": {},
+	}
+
+	visited := make(map[string]bool)
+	dfs(graph, "A", visited)
+}


### PR DESCRIPTION
Affects #40

Quick note: The implementation uses a visited-hashmap instead of a visited-array due to the data being of `string` type. An array can be utilized if the data was `int`.